### PR TITLE
Add support for libunwind

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -31,6 +31,10 @@ CFLAGS="$CFLAGS -Winit-self"
 CFLAGS="$CFLAGS -Wno-strict-aliasing"
 CFLAGS="$CFLAGS -Wno-implicit-fallthrough"
 
+# Feels a bit dirty but oh well
+grep -q '^#define PMEM_LIBUNWIND$' "${PREFIX}/config.h" && \
+    CFLAGS="$CFLAGS -lunwind"
+
 OBJ=""
 for src in "${SRC[@]}"; do
     $CC -c -o "$src.o" "${PREFIX}/src/$src.c" $CFLAGS

--- a/config.h
+++ b/config.h
@@ -1,3 +1,7 @@
 
+// If defined, pmem will use libunwind to collect the source's stack
+// frames. Otherwise, pmem will fallback on glibc's backtrace.
+#define PMEM_LIBUNWIND
+
 // Defines the threshold to dump a memory profile in bytes allocated and freed.
 #define PMEM_CHURN_THRESH (1UL << 20) // 1Mb


### PR DESCRIPTION
```
[1345]=========================================================
churn=1048576/1048576

{939ed22340948b85} live:14, alloc:0/120000, free:16/119986
  {0} prof_alloc+286
  {1} malloc+28
  {2} main+148
  {3} __libc_start_main+243
  {4} _start+46
```
Stacktraces are less shit now